### PR TITLE
Make returning a specific statement optional

### DIFF
--- a/bin/tinkeray.php
+++ b/bin/tinkeray.php
@@ -1,22 +1,56 @@
 <?php
 
-class TinkerayOutputException extends Exception {}
+function generateAst($filename)
+{
+    $code = file_get_contents($filename);
+    $parser = (new PhpParser\ParserFactory())->create(PhpParser\ParserFactory::PREFER_PHP7);
+    return $parser->parse($code);
+}
 
-function getReturnFromIncludeOrFail($filename) {
-    $php = str_replace('<?php', '', file_get_contents($filename));
-    $php .= PHP_EOL.'throw new TinkerayOutputException;';
+function removeCommentLines($ast)
+{
+    $traverser = new PhpParser\NodeTraverser();
+    $traverser->addVisitor(new class () extends PhpParser\NodeVisitorAbstract {
+        public function leaveNode(PhpParser\Node $node)
+        {
+            if ($node instanceof PhpParser\Node\Stmt\Nop) {
+                return PhpParser\NodeTraverser::REMOVE_NODE;
+            }
+        }
+    });
 
-    return eval($php);
+    return $traverser->traverse($ast);
+}
+
+function enforceReturnValue($ast)
+{
+    $lastStmt = array_pop($ast);
+
+    switch ($lastStmt->getType()) {
+        case 'Stmt_Expression':
+            $ast[] = new PhpParser\Node\Stmt\Return_($lastStmt->expr);
+            break;
+        case 'Stmt_Return':
+        case 'Stmt_Echo':
+        default:
+            $ast[] = $lastStmt;
+    }
+
+    return $ast;
+}
+
+function evaluateTinkerFile($filename)
+{
+    $ast = enforceReturnValue(removeCommentLines(generateAst($filename)));
+    $executionCode = (new PhpParser\PrettyPrinter\Standard())->prettyPrint($ast);
+
+    return eval($executionCode);
 }
 
 try {
-    ray(getReturnFromIncludeOrFail(getenv('TINKERAY_APP_PATH') . '/tinkeray.php'));
+    ray(evaluateTinkerFile(getenv('TINKERAY_APP_PATH') . '/tinkeray.php'));
 } catch (Throwable $t) {
-    if ($t instanceof TinkerayOutputException) {
-        ray('Warning: No `return` detected in [tinkeray.php]!')->orange();
-    } else {
-        ray()->exception($t);
-    }
+    ray()->exception($t);
 }
 
 exit;

--- a/bin/tinkeray.php
+++ b/bin/tinkeray.php
@@ -3,13 +3,16 @@
 function generateAst($filename)
 {
     $code = file_get_contents($filename);
-    $parser = (new PhpParser\ParserFactory())->create(PhpParser\ParserFactory::PREFER_PHP7);
+
+    $parser = (new PhpParser\ParserFactory)->create(PhpParser\ParserFactory::PREFER_PHP7);
+
     return $parser->parse($code);
 }
 
 function removeCommentLines($ast)
 {
-    $traverser = new PhpParser\NodeTraverser();
+    $traverser = new PhpParser\NodeTraverser;
+
     $traverser->addVisitor(new class () extends PhpParser\NodeVisitorAbstract {
         public function leaveNode(PhpParser\Node $node)
         {
@@ -42,7 +45,7 @@ function enforceReturn($ast)
 function evaluateTinkerFile($filename)
 {
     $ast = enforceReturn(removeCommentLines(generateAst($filename)));
-    $executionCode = (new PhpParser\PrettyPrinter\Standard())->prettyPrint($ast);
+    $executionCode = (new PhpParser\PrettyPrinter\Standard)->prettyPrint($ast);
 
     return eval($executionCode);
 }

--- a/bin/tinkeray.php
+++ b/bin/tinkeray.php
@@ -1,5 +1,7 @@
 <?php
 
+class TinkerayOutputException extends Exception {}
+
 function generateAst($filename)
 {
     $code = file_get_contents($filename);
@@ -29,6 +31,10 @@ function enforceReturn($ast)
 {
     $lastStmt = array_pop($ast);
 
+    if (! $lastStmt) {
+        throw new TinkerayOutputException;
+    }
+
     switch ($lastStmt->getType()) {
         case 'Stmt_Expression':
             $ast[] = new PhpParser\Node\Stmt\Return_($lastStmt->expr);
@@ -53,7 +59,11 @@ function evaluateTinkerFile($filename)
 try {
     ray(evaluateTinkerFile(getenv('TINKERAY_APP_PATH') . '/tinkeray.php'));
 } catch (Throwable $t) {
-    ray()->exception($t);
+    if ($t instanceof TinkerayOutputException) {
+        ray('Nothing to output in [tinkeray.php]!')->orange();
+    } else {
+        ray()->exception($t);
+    }
 }
 
 exit;

--- a/bin/tinkeray.php
+++ b/bin/tinkeray.php
@@ -22,7 +22,7 @@ function removeCommentLines($ast)
     return $traverser->traverse($ast);
 }
 
-function enforceReturnValue($ast)
+function enforceReturn($ast)
 {
     $lastStmt = array_pop($ast);
 
@@ -41,7 +41,7 @@ function enforceReturnValue($ast)
 
 function evaluateTinkerFile($filename)
 {
-    $ast = enforceReturnValue(removeCommentLines(generateAst($filename)));
+    $ast = enforceReturn(removeCommentLines(generateAst($filename)));
     $executionCode = (new PhpParser\PrettyPrinter\Standard())->prettyPrint($ast);
 
     return eval($executionCode);


### PR DESCRIPTION
This PR uses AST and a PHP Parser to automatically enforce a return value for the final executed statement in the `tinkeray.php` file.

The first explicit return in the file will still take precedence, but if no values are returned, the final statement will fall back to a return call.

https://user-images.githubusercontent.com/2329654/155303129-092566e1-70cc-40e1-9a56-2f5edd8d162d.mp4

