### PR TITLE
Update parser create method for PHP-Parser v5

### DIFF
--- a/bin/tinkeray.php
+++ b/bin/tinkeray.php
@@ -9,7 +9,7 @@ function generateAst($filename)
 {
     $code = file_get_contents($filename);
 
-    $parser = (new PhpParser\ParserFactory)->create(PhpParser\ParserFactory::PREFER_PHP7);
+    $parser = (new PhpParser\ParserFactory)->createForHostVersion();
 
     return $parser->parse($code);
 }

--- a/bin/tinkeray.php
+++ b/bin/tinkeray.php
@@ -9,7 +9,10 @@ function generateAst($filename)
 {
     $code = file_get_contents($filename);
 
-    $parser = (new PhpParser\ParserFactory)->createForHostVersion();
+    // Use `createForHostVersion()`, otherwise fall back to legacy `create()` method which was removed in v5
+    $parser = method_exists('PhpParser\ParserFactory', 'createForHostVersion')
+        ? (new PhpParser\ParserFactory)->createForHostVersion()
+        : (new PhpParser\ParserFactory)->create(PhpParser\ParserFactory::PREFER_PHP7);
 
     return $parser->parse($code);
 }


### PR DESCRIPTION
I had a weird bug where tinkeray just stopped working all together:

![CleanShot 2024-03-05 at 21 49 29@2x](https://github.com/jesseleite/vim-tinkeray/assets/32152670/a6d27905-40b3-4c3d-9499-f48461ab61f3)

After digging around a bit, I found that the `ParserFactory::create()` method was removed in `nikic/PHP-Parser` v5 (see: https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-parser-factory). They propose using one of three methods, so I picked out `createForHostVersion()` as probably the best replacement. This method also exists in v4 of `nikic/PHP-Parser`, so this *should* still work in older versions.

I think this is probably related to https://github.com/laravel/tinker/pull/170

Manually changing this line in my installed version of `tinkeray` seems to have fixed the problem, but I'm not sure how to do more thorough testing.